### PR TITLE
Ref #34 -- Fix DatePickerDialog popup bug

### DIFF
--- a/app/src/main/res/layout/fragment_add.xml
+++ b/app/src/main/res/layout/fragment_add.xml
@@ -6,7 +6,8 @@
     android:paddingRight="15sp"
     android:paddingTop="15sp"
     android:paddingBottom="15sp"
-    android:background="@color/white">
+    android:background="@color/white"
+    android:focusableInTouchMode="true">
 
 
     <android.support.design.widget.TextInputLayout


### PR DESCRIPTION
- `ToduleAddFragment` continuously focus on dateEdit upon any dialog dismissal. By setting the parent layout as focusableInTouchMode fixed this bug.

Fixes #34