### PR TITLE
Fix #70 -- Wrong time remaining in notification message

### DIFF
--- a/app/src/main/java/com/danlls/daniel/todule_android/activities/NotificationReceiver.java
+++ b/app/src/main/java/com/danlls/daniel/todule_android/activities/NotificationReceiver.java
@@ -15,6 +15,7 @@ import android.util.Log;
 
 import com.danlls.daniel.todule_android.R;
 import com.danlls.daniel.todule_android.provider.ToduleDBContract;
+import com.danlls.daniel.todule_android.utilities.DateTimeUtils;
 import com.danlls.daniel.todule_android.utilities.NotificationHelper;
 
 import static android.content.Context.NOTIFICATION_SERVICE;
@@ -96,7 +97,7 @@ public class NotificationReceiver extends BroadcastReceiver {
                             new NotificationCompat.Builder(context, CHANNEL_ID)
                                     .setSmallIcon(R.drawable.ic_stat_todule)
                                     .setContentTitle("Reminder: " + intent.getStringExtra("todule_title"))
-                                    .setContentText(intent.getStringExtra("todule_due_date"))
+                                    .setContentText(DateTimeUtils.dateTimeDiff(System.currentTimeMillis(),intent.getLongExtra("todule_due_date", -1L)))
                                     .setContentIntent(resultPendingIntent)
                                     .setDeleteIntent(notifDeletePendingIntent)
                                     .setAutoCancel(true);

--- a/app/src/main/java/com/danlls/daniel/todule_android/activities/ToduleDetailFragment.java
+++ b/app/src/main/java/com/danlls/daniel/todule_android/activities/ToduleDetailFragment.java
@@ -104,8 +104,8 @@ public class ToduleDetailFragment extends Fragment {
 
         String createDateString = DateUtils.formatDateTime(getContext(), createdDate, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_ABBREV_ALL | DateUtils.FORMAT_SHOW_TIME);
         String dueDateString = DateUtils.formatDateTime(getContext(), dueDate, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_ABBREV_ALL | DateUtils.FORMAT_SHOW_TIME);
-        String countdownString =  DateTimeUtils.dateTimeDiff(dueDate);
-        String completeDateString = DateTimeUtils.dateTimeDiff(completeDate);
+        String countdownString =  DateTimeUtils.dateTimeDiff(System.currentTimeMillis() ,dueDate);
+        String completeDateString = DateTimeUtils.dateTimeDiff(System.currentTimeMillis(), completeDate);
 
         if(taskDone == ToduleDBContract.TodoEntry.TASK_NOT_COMPLETED){
             if(dueDate < System.currentTimeMillis()) {

--- a/app/src/main/java/com/danlls/daniel/todule_android/adapter/MainCursorAdapter.java
+++ b/app/src/main/java/com/danlls/daniel/todule_android/adapter/MainCursorAdapter.java
@@ -44,7 +44,7 @@ public class MainCursorAdapter extends CursorAdapter {
         String description = cursor.getString(cursor.getColumnIndexOrThrow(TodoEntry.COLUMN_NAME_DESCRIPTION));
         long dueDate = cursor.getLong(cursor.getColumnIndexOrThrow(TodoEntry.COLUMN_NAME_DUE_DATE));
         String dueDateString = DateUtils.formatDateTime(context, dueDate, DateUtils.FORMAT_SHOW_DATE | DateUtils.FORMAT_ABBREV_ALL | DateUtils.FORMAT_SHOW_TIME);
-        String countdownString =  DateTimeUtils.dateTimeDiff(dueDate);
+        String countdownString =  DateTimeUtils.dateTimeDiff(System.currentTimeMillis(), dueDate);
         if (!cursor.isNull(cursor.getColumnIndexOrThrow(TodoEntry.COLUMN_NAME_LABEL))){
             Long labelId = cursor.getLong(cursor.getColumnIndexOrThrow(TodoEntry.COLUMN_NAME_LABEL));
             Uri labelUri = ContentUris.withAppendedId(ToduleDBContract.TodoLabel.CONTENT_ID_URI_BASE, labelId);

--- a/app/src/main/java/com/danlls/daniel/todule_android/utilities/DateTimeUtils.java
+++ b/app/src/main/java/com/danlls/daniel/todule_android/utilities/DateTimeUtils.java
@@ -13,10 +13,10 @@ public final class DateTimeUtils {
         return then - now;
     }
 
-    public static String dateTimeDiff (long then) {
+    public static String dateTimeDiff (long from, long to) {
         String result;
         String pastOrFuture;
-        long diff = millisDiffFromNow(then);
+        long diff = to - from;
         if (diff < 0 ) {
             pastOrFuture = " ago";
         } else {

--- a/app/src/main/java/com/danlls/daniel/todule_android/utilities/NotificationHelper.java
+++ b/app/src/main/java/com/danlls/daniel/todule_android/utilities/NotificationHelper.java
@@ -27,14 +27,14 @@ public class NotificationHelper {
         long itemId = Long.valueOf(toduleUri.getLastPathSegment());
         String title = cr.getString(cr.getColumnIndexOrThrow(ToduleDBContract.TodoEntry.COLUMN_NAME_TITLE));
         long dueDate = cr.getLong(cr.getColumnIndexOrThrow(ToduleDBContract.TodoEntry.COLUMN_NAME_DUE_DATE));
-        String dueDateString = DateTimeUtils.dateTimeDiff(dueDate);
+//        String dueDateString = DateTimeUtils.dateTimeDiff(dueDate - 60 * 60 * 1000 , dueDate);
 
         Intent intent = new Intent(context, NotificationReceiver.class);
         intent.setData(Uri.parse(R.string.reminder_intent_scheme + String.valueOf(itemId)));
         intent.setAction("com.danlls.daniel.todule_android.REMINDER_NOTIFICATION");
         intent.putExtra("todule_id", itemId);
         intent.putExtra("todule_title", title);
-        intent.putExtra("todule_due_date", dueDateString);
+        intent.putExtra("todule_due_date", dueDate);
         PendingIntent sender = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
         cr.close();
         return sender;


### PR DESCRIPTION
- Modify `dateTimeUtil` in `DateTimeUtils` to remove coupling
- Fix time remaining bug by determining time remaining during broadcast receive instead
of preset in pending intent

Fixes #70